### PR TITLE
Some code refactoring and stop passing hashes and arrays around

### DIFF
--- a/lib/HTML/SocialMeta.pm
+++ b/lib/HTML/SocialMeta.pm
@@ -36,7 +36,7 @@ has 'opengraph' => (
 has 'schema' => (
     isa        => 'HTML::SocialMeta::Schema',
     is         => 'ro',
-    lazy_build => 1,
+    lazy       => 1,
     builder    => 'build_schema',
 );
 

--- a/lib/HTML/SocialMeta/OpenGraph.pm
+++ b/lib/HTML/SocialMeta/OpenGraph.pm
@@ -13,25 +13,29 @@ has 'meta_attribute' =>
 has 'meta_namespace' =>
   ( isa => 'Str', is => 'ro', required => 1, default => 'og' );
 
-sub card_options {
-    return (
-        summary        => q(create_thumbnail),
-        featured_image => q(create_article),
-        player         => q(create_video),
-        app            => q(create_product),
-    );
-}
+has '+card_options' => (
+    default => sub {
+        return {
+            summary        => q(create_thumbnail),
+            featured_image => q(create_article),
+            player         => q(create_video),
+            app            => q(create_product),
+        };
+    },
+);
 
-sub build_fields {
-    return (
-        thumbnail => [qw(type title description url image site_name)],
-        article   => [qw(type title description url image site_name)],
-        video     => [
-            qw(type site_name url title image description player player_width player_height)
-        ],
-        product => [qw(type title image description url)]
-    );
-}
+has '+build_fields' => (
+    default => sub {
+        return {
+            thumbnail => [qw(type title description url image site_name)],
+            article   => [qw(type title description url image site_name)],
+            video     => [
+                qw(type site_name url title image description player player_width player_height)
+            ],
+            product => [qw(type title image description url)]
+        };
+    },
+);
 
 sub create_thumbnail {
     my ($self) = @_;

--- a/lib/HTML/SocialMeta/Schema.pm
+++ b/lib/HTML/SocialMeta/Schema.pm
@@ -14,23 +14,27 @@ has 'meta_namespace' =>
   ( isa => 'Str', is => 'ro', required => 1, default => 'content' );
 has 'item_type' => ( isa => 'Str', is => 'rw', required => 1, default => q{} );
 
-sub card_options {
-    return (
-        summary        => q(create_article),
-        featured_image => q(create_offer),
-        player         => q(create_video),
-        app            => q(create_software_application),
-    );
-}
+has '+card_options' => (
+	default => sub {
+		return {
+			summary        => q(create_article),
+			featured_image => q(create_offer),
+			player         => q(create_video),
+			app            => q(create_software_application),
+		};
+	},
+);
 
-sub build_fields {
-    return (
-        article => [qw(name description image)],
-        offer   => [qw(name description image)],
-        video => [qw(name description image player player_width player_height)],
-        software_application => [qw(name description image operatingSystem url)]
-    );
-}
+has '+build_fields' => (
+	default => sub {
+		return {
+			article => [qw(name description image)],
+			offer   => [qw(name description image)],
+			video => [qw(name description image player player_width player_height)],
+			software_application => [qw(name description image operatingSystem url)]
+		};
+	},
+);
 
 sub create_article {
     my ($self) = @_;

--- a/lib/HTML/SocialMeta/Twitter.pm
+++ b/lib/HTML/SocialMeta/Twitter.pm
@@ -14,26 +14,30 @@ has 'meta_attribute' =>
 has 'meta_namespace' =>
   ( isa => 'Str', is => 'ro', required => 1, default => 'twitter' );
 
-sub card_options {
-    return (
-        summary        => q(create_summary),
-        featured_image => q(create_summary_large_image),
-        app            => q(create_app),
-        player         => q(create_player),
-    );
-}
+has '+card_options' => (
+	default => sub {
+		return {
+			summary        => q(create_summary),
+			featured_image => q(create_summary_large_image),
+			app            => q(create_app),
+			player         => q(create_player),
+		};
+	},
+);
 
-sub build_fields {
-    return (
-        summary             => [qw(card site title description image)],
-        summary_large_image => [qw(card site title description image)],
-        app =>
-          [ qw(card site description app_country app_name app_id app_url) ],
-        player => [
-            qw(card site title description image player player_width player_height)
-        ],
-    );
-}
+has '+build_fields' => (
+	default => sub {
+		return {
+			summary             => [qw(card site title description image)],
+			summary_large_image => [qw(card site title description image)],
+			app =>
+			  [ qw(card site description app_country app_name app_id app_url) ],
+			player => [
+				qw(card site title description image player player_width player_height)
+			],
+		};
+	},
+);
 
 sub create_summary {
     my ($self) = @_;


### PR DESCRIPTION
You left a lazy_build in there, so I converted that to a lazy. Also your build_fields and card_options methods should really be initialise once attributes that return HashRefs, you need to get out of the habit of passing hashes and arrays around. At one point you were creating a copy of a hash to get at an arrayref that you were then copying into an array so that you could return the array to be copied into another array. That's a lot of copying for something that is only used internally and isn't mutated at any point.