### PR TITLE
Use HTML entity encoding

### DIFF
--- a/lib/HTML/SocialMeta/Base.pm
+++ b/lib/HTML/SocialMeta/Base.pm
@@ -72,10 +72,16 @@ sub _generate_meta_tag {
 }
 
 sub _build_field {
+    my $content = $_[0]->{ $_[1]->{field} };
+    $content =~ s/&/&amp;/g;
+    $content =~ s/"/&quot;/g;
+    $content =~ s/'/&apos;/g;
+    $content =~ s/</&lt;/g;
+    $content =~ s/>/&gt;/g;
     return sprintf q{<meta %s="%s:%s" content="%s"/>}, $_[0]->meta_attribute,
       ( $_[1]->{ignore_meta_namespace} // $_[0]->meta_namespace ),
       ( defined $_[1]->{field_type} ? $_[1]->{field_type} : $_[1]->{field} ),
-      $_[0]->{ $_[1]->{field} };
+      $content;
 }
 
 sub _convert_field {

--- a/t/04-create.t
+++ b/t/04-create.t
@@ -11,7 +11,7 @@ my $meta_tags = HTML::SocialMeta->new(
     site => '@example_twitter',
     site_name => 'Example Site, anything',
     title => 'You can have any title you wish here',
-    description => 'Description goes here may have to do a little validation',
+    description => 'Description goes here may have to do a little "validation"',
     image => 'www.urltoimage.com/blah.jpg',
     url	 => 'www.someurl.com',
     player => 'www.somevideourl.com/url/url',
@@ -26,11 +26,11 @@ my $tags = $meta_tags->create;
 my $test_create_all = '<meta name="twitter:card" content="summary"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
-<meta name="twitter:description" content="Description goes here may have to do a little validation"/>
+<meta name="twitter:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
 <meta property="og:type" content="thumbnail"/>
 <meta property="og:title" content="You can have any title you wish here"/>
-<meta property="og:description" content="Description goes here may have to do a little validation"/>
+<meta property="og:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
 <meta property="og:site_name" content="Example Site, anything"/>
@@ -44,7 +44,7 @@ my $twitter_create = $twitter_tags->create('featured_image');
 my $test_twitter_featured = '<meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
-<meta name="twitter:description" content="Description goes here may have to do a little validation"/>
+<meta name="twitter:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
 
 is($twitter_create, $test_twitter_featured);
@@ -55,7 +55,7 @@ my $generic_twitter_create = $twitter_tags->create();
 my $test_twitter = '<meta name="twitter:card" content="summary"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
-<meta name="twitter:description" content="Description goes here may have to do a little validation"/>
+<meta name="twitter:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
 
 is($generic_twitter_create, $test_twitter);
@@ -65,11 +65,11 @@ my $create_featured = $meta_tags->create('featured_image');
 my $test_featured_all = '<meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
-<meta name="twitter:description" content="Description goes here may have to do a little validation"/>
+<meta name="twitter:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
 <meta property="og:type" content="article"/>
 <meta property="og:title" content="You can have any title you wish here"/>
-<meta property="og:description" content="Description goes here may have to do a little validation"/>
+<meta property="og:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
 <meta property="og:site_name" content="Example Site, anything"/>
@@ -82,7 +82,7 @@ my $create_player = $meta_tags->create('player');
 my $test_player_card = '<meta name="twitter:card" content="player"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
-<meta name="twitter:description" content="Description goes here may have to do a little validation"/>
+<meta name="twitter:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
 <meta name="twitter:player" content="www.somevideourl.com/url/url"/>
 <meta name="twitter:player:width" content="500"/>
@@ -92,7 +92,7 @@ my $test_player_card = '<meta name="twitter:card" content="player"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
-<meta property="og:description" content="Description goes here may have to do a little validation"/>
+<meta property="og:description" content="Description goes here may have to do a little &quot;validation&quot;"/>
 <meta property="og:video:url" content="www.somevideourl.com/url/url"/>
 <meta property="og:video:secure_url" content="www.somevideourl.com/url/url"/>
 <meta property="og:video:width" content="500"/>


### PR DESCRIPTION
This addresses a bug where a user-provided value of e.g. `This is a painting called "Starry Night"` would result in broken HTML (from trying to put an unencoded `"` into the middle of an attribute value).