### PR TITLE
Alt text

### DIFF
--- a/lib/HTML/SocialMeta.pm
+++ b/lib/HTML/SocialMeta.pm
@@ -12,7 +12,7 @@ use Types::Standard qw/Str Object ArrayRef/;
 our $VERSION = '0.71';
 
 attributes(
-    [qw(card_type card site site_name title description image url creator operatingSystem 
+    [qw(card_type card site site_name title description image image_alt url creator operatingSystem
     app_country app_name app_id app_url player player_height player_width fb_app_id)] => [ Str, {lzy} ],
     [qw(twitter opengraph)] => [ Object, { lzy, bld } ],
     social => [ sub { [qw/twitter opengraph/] } ],
@@ -41,7 +41,7 @@ sub _build_twitter {
     HTML::SocialMeta::Twitter->new(
         (
             map { defined $_[0]->$_ ? ( $_ => $_[0]->$_ ) : () }
-              qw/card_type site title description image url creator
+              qw/card_type site title description image image_alt url creator
               operatingSystem app_country app_name app_id app_url
               player player_width player_height/
         )
@@ -53,7 +53,7 @@ sub _build_opengraph {
         (
             map { defined $_[0]->$_ ? ( $_ => $_[0]->$_ ) : () }
               qw/card_type site_name title description image operatingSystem player
-              player_width player_height fb_app_id/
+              image_alt player_width player_height fb_app_id/
         ),
         (
             $_[0]->app_url || $_[0]->url
@@ -187,9 +187,13 @@ A description of the content in a maximum of 200 characters
 
 A URL to a unique image representing the content of the page
 
+=item image_alt
+
+A text description of the image, for use by vision-impaired users
+
 =item url
 
-OPTIONAL OPENGRAPH - allows you to specify an alternative url link you want the reader to be redirected 
+OPTIONAL OPENGRAPH - allows you to specify an alternative url link you want the reader to be redirected
 
 =item player
 
@@ -291,6 +295,7 @@ Fields Required:
     * creator - Twitter
     * title
     * image
+    * image_alt
     * url - Open Graph
 
 =cut
@@ -314,30 +319,31 @@ The Player Card allows you to share Video clips and audio stream.
 
 Returns an instance for the player card:
 
-    $card->create('player');	
+    $card->create('player');
     # call meta provider specifically
     $card->twitter->create_player;
     $card->opengraph->create_video;
 
 Fields Required:
- 
-    * site 
-    * title 
-    * description 
-    * image 
-    * player                
-    * player_width           
-    * player_height     
+
+    * site
+    * title
+    * description
+    * image
+    * image_alt
+    * player
+    * player_width
+    * player_height
 
 image to be displayed in place of the player on platforms that does not support iframes or inline players. You should make this image the same dimensions
-as your player. Images with fewer than 68,600 pixels (a 262 x 262 square image, or a 350 x 196 16:9 image) will cause the player card not to render. 
-Image must be less than 1MB in size 
+as your player. Images with fewer than 68,600 pixels (a 262 x 262 square image, or a 350 x 196 16:9 image) will cause the player card not to render.
+Image must be less than 1MB in size
 
 =cut
 
 =head2 App Card
 
-The App Card is a great way to represent mobile applications on Social Media Platforms and to drive installs. 
+The App Card is a great way to represent mobile applications on Social Media Platforms and to drive installs.
 
     ,-----------------------------------,
     |   APP NAME              *-------* |

--- a/lib/HTML/SocialMeta.pm
+++ b/lib/HTML/SocialMeta.pm
@@ -189,7 +189,7 @@ A URL to a unique image representing the content of the page
 
 =item image_alt
 
-A text description of the image, for use by vision-impaired users
+OPTIONAL - A text description of the image, for use by vision-impaired users
 
 =item url
 
@@ -295,8 +295,11 @@ Fields Required:
     * creator - Twitter
     * title
     * image
-    * image_alt
     * url - Open Graph
+
+Optional Fields:
+
+    * image_alt
 
 =cut
 
@@ -330,10 +333,13 @@ Fields Required:
     * title
     * description
     * image
-    * image_alt
     * player
     * player_width
     * player_height
+
+Optional Fields:
+
+    * image_alt
 
 image to be displayed in place of the player on platforms that does not support iframes or inline players. You should make this image the same dimensions
 as your player. Images with fewer than 68,600 pixels (a 262 x 262 square image, or a 350 x 196 16:9 image) will cause the player card not to render.

--- a/lib/HTML/SocialMeta/Base.pm
+++ b/lib/HTML/SocialMeta/Base.pm
@@ -11,7 +11,7 @@ use Types::Standard qw/Str HashRef/;
 attributes(
     [qw(card_type card type name url)] => [ rw, Str, {lzy} ],
     [qw(site fb_app_id site_name title description image creator operatingSystem app_country
-    app_name app_id app_url player player_height player_width)] => [ Str, {lzy} ],
+    app_name app_id app_url player player_height player_width image_alt)] => [ Str, {lzy} ],
     [qw(card_options build_fields)] => [HashRef,{default => sub { {} }}],
     [qw(meta_attribute meta_namespace)] => [ro],
 );
@@ -63,8 +63,8 @@ sub _validate_field_value {
 
 sub _generate_meta_tag {
 
-    # fields that don't start with app or player generate a single tag
-    $_[1] !~ m{^app|player|fb}xms
+    # fields that don't start with app, player, or image generate a single tag
+    $_[1] !~ m{^app|player|fb|image}xms
       and return $_[0]->_build_field( { field => $_[1] } );
     return
       map { $_[0]->_build_field( { field => $_[1], %{$_} } ) }
@@ -119,19 +119,20 @@ Version 0.71
 =head1 SYNOPSIS
 
     use HTML::SocialMeta;
-    # summary or featured image 
+    # summary or featured image
     my $social = HTML::SocialMeta->new(
         site => '',
         site_name => '',
         title => '',
         description => '',
         image   => '',
+        image_alt => '',
         url  => '',  # optional
         ... => '',
         ... => '',
     );
 
-    # returns meta tags for all providers   
+    # returns meta tags for all providers
     # 'summary', 'featured_image', 'app', 'player'
     my $meta_tags = $social->create('summary');
 

--- a/lib/HTML/SocialMeta/Base.pm
+++ b/lib/HTML/SocialMeta/Base.pm
@@ -11,7 +11,8 @@ use Types::Standard qw/Str HashRef/;
 attributes(
     [qw(card_type card type name url)] => [ rw, Str, {lzy} ],
     [qw(site fb_app_id site_name title description image creator operatingSystem app_country
-    app_name app_id app_url player player_height player_width image_alt)] => [ Str, {lzy} ],
+    app_name app_id app_url player player_height player_width)] => [ Str, {lzy} ],
+    [qw(image_alt)] => [ Str, {lzy => 1, default => ''} ],
     [qw(card_options build_fields)] => [HashRef,{default => sub { {} }}],
     [qw(meta_attribute meta_namespace)] => [ro],
 );

--- a/lib/HTML/SocialMeta/OpenGraph.pm
+++ b/lib/HTML/SocialMeta/OpenGraph.pm
@@ -28,13 +28,13 @@ attributes(
         sub {
             return {
                 thumbnail =>
-                  [qw(type title description url image site_name fb_app_id)],
+                  [qw(type title description url image image_alt site_name fb_app_id)],
                 article =>
-                  [qw(type title description url image site_name fb_app_id)],
+                  [qw(type title description url image image_alt site_name fb_app_id)],
                 video => [
-                    qw(type site_name url title image description player player_width player_height fb_app_id)
+                    qw(type site_name url title image image_alt description player player_width player_height fb_app_id)
                 ],
-                product => [qw(type title image description url fb_app_id)]
+                product => [qw(type title image image_alt description url fb_app_id)]
             };
         }
     ],

--- a/lib/HTML/SocialMeta/Twitter.pm
+++ b/lib/HTML/SocialMeta/Twitter.pm
@@ -27,13 +27,13 @@ attributes(
     '+build_fields' => [
         sub {
             {
-                summary             => [qw(card site title description image)],
-                summary_large_image => [qw(card site title description image)],
+                summary             => [qw(card site title description image image_alt)],
+                summary_large_image => [qw(card site title description image image_alt)],
                 app                 => [
                     qw(card site description app_country app_name app_id app_url)
                 ],
                 player => [
-                    qw(card site title description image player player_width player_height)
+                    qw(card site title description image image_alt player player_width player_height)
                 ],
             };
         }

--- a/t/01-base.t
+++ b/t/01-base.t
@@ -15,6 +15,7 @@ my $bad_meta_tags = HTML::SocialMeta->new(
     site_name => 'Example Site, anything',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url	 => 'www.someurl.com',
 );
 
@@ -25,8 +26,8 @@ throws_ok{$bad_meta_tags->opengraph->create_article} qr/you have not set this fi
 my $social = HTML::SocialMeta->new();
 my @social_required_fields = $social->required_fields('summary');
 
-my @expected_fields = ( qw{name description image card site title type site_name fb_app_id} );
-my @expected_player_fields = ( qw{name description image card site title player player_width player_height type site_name fb_app_id} );
+my @expected_fields = ( qw{name description image image_alt card site title type site_name fb_app_id} );
+my @expected_player_fields = ( qw{name description image image_alt card site title player player_width player_height type site_name fb_app_id} );
 
 is(@social_required_fields, @expected_fields);
 

--- a/t/02-twitter.t
+++ b/t/02-twitter.t
@@ -15,11 +15,12 @@ my $meta_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url	 => 'www.someurl.com',
     operatingSystem => 'ANDROID',
     app_country => 'test',
     app_name => 'test',
-    app_id => 'test', 
+    app_id => 'test',
     app_url => 'test',
     player      => 'www.urltovideo.com/blah.jpg',
     player_width => '500',
@@ -32,6 +33,7 @@ my $meta_player_tags = HTML::SocialMeta->new(
     description => 'Description goes here may have to do a little validation',
     player => 'www.urltovideo.com/blah.jpg',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     player_width => '500',
     player_height => '500',
 );
@@ -43,11 +45,12 @@ my $ios_app_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url  => 'www.someurl.com',
     operatingSystem => 'IOS',
     app_country => 'US',
     app_name => 'tester twitter',
-    app_id => '1232', 
+    app_id => '1232',
     app_url => 'app.app.com/app',
 );
 
@@ -64,7 +67,8 @@ my $test_twitter = '<meta name="twitter:card" content="summary"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
-<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
+<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>';
 
 is($twitter->create('summary'), $test_twitter);
 is($twitter_summary_card, $test_twitter);
@@ -73,7 +77,8 @@ my $test_twitter_featured = '<meta name="twitter:card" content="summary_large_im
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
-<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
+<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>';
 
 is($twitter->create('featured_image'), $test_twitter_featured);
 is($twitter_featured_image_card, $test_twitter_featured);
@@ -94,6 +99,7 @@ my $test_player_card = '<meta name="twitter:card" content="player"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>
 <meta name="twitter:player" content="www.urltovideo.com/blah.jpg"/>
 <meta name="twitter:player:width" content="500"/>
 <meta name="twitter:player:height" content="500"/>';

--- a/t/03-opengraph.t
+++ b/t/03-opengraph.t
@@ -14,6 +14,7 @@ my $meta_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url	 => 'www.someurl.com',
     player => 'www.somevideourl.com/url/url',
     player_width => '500',
@@ -34,6 +35,7 @@ my $test_opengraph = '<meta property="og:type" content="article"/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:site_name" content="Example Site, anything"/>
 <meta property="fb:app_id" content="1232342342354"/>';
 
@@ -45,6 +47,7 @@ my $test_opengraph_thumbnail = '<meta property="og:type" content="thumbnail"/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:site_name" content="Example Site, anything"/>
 <meta property="fb:app_id" content="1232342342354"/>';
 
@@ -56,6 +59,7 @@ my $test_video_card = '<meta property="og:type" content="video"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:video:url" content="www.somevideourl.com/url/url"/>
 <meta property="og:video:secure_url" content="www.somevideourl.com/url/url"/>
@@ -72,6 +76,7 @@ my $app_meta_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     app_url	 => 'www.someurl.com',
     fb_app_id	=> '1232342342354',
 );
@@ -79,6 +84,7 @@ my $app_meta_tags = HTML::SocialMeta->new(
 my $test_app = '<meta property="og:type" content="product"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="fb:app_id" content="1232342342354"/>';

--- a/t/04-create.t
+++ b/t/04-create.t
@@ -13,6 +13,7 @@ my $meta_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url	 => 'www.someurl.com',
     player => 'www.somevideourl.com/url/url',
     player_width => '500',
@@ -28,11 +29,13 @@ my $test_create_all = '<meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>
 <meta property="og:type" content="thumbnail"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:site_name" content="Example Site, anything"/>
 <meta property="fb:app_id" content="1232342342354"/>';
 
@@ -45,7 +48,8 @@ my $test_twitter_featured = '<meta name="twitter:card" content="summary_large_im
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
-<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
+<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>';
 
 is($twitter_create, $test_twitter_featured);
 
@@ -56,7 +60,8 @@ my $test_twitter = '<meta name="twitter:card" content="summary"/>
 <meta name="twitter:site" content="@example_twitter"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
-<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>';
+<meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>';
 
 is($generic_twitter_create, $test_twitter);
 
@@ -67,11 +72,13 @@ my $test_featured_all = '<meta name="twitter:card" content="summary_large_image"
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>
 <meta property="og:type" content="article"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:site_name" content="Example Site, anything"/>
 <meta property="fb:app_id" content="1232342342354"/>';
 
@@ -84,6 +91,7 @@ my $test_player_card = '<meta name="twitter:card" content="player"/>
 <meta name="twitter:title" content="You can have any title you wish here"/>
 <meta name="twitter:description" content="Description goes here may have to do a little validation"/>
 <meta name="twitter:image" content="www.urltoimage.com/blah.jpg"/>
+<meta name="twitter:image:alt" content="A picture of some stuff."/>
 <meta name="twitter:player" content="www.somevideourl.com/url/url"/>
 <meta name="twitter:player:width" content="500"/>
 <meta name="twitter:player:height" content="500"/>
@@ -92,6 +100,7 @@ my $test_player_card = '<meta name="twitter:card" content="player"/>
 <meta property="og:url" content="www.someurl.com"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:video:url" content="www.somevideourl.com/url/url"/>
 <meta property="og:video:secure_url" content="www.somevideourl.com/url/url"/>
@@ -110,11 +119,12 @@ my $android_app_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url  => 'www.someurl.com',
     operatingSystem => 'ANDROID',
     app_country => 'US',
     app_name => 'tester twitter',
-    app_id => '1232', 
+    app_id => '1232',
     app_url => 'app.app.com/app',
     fb_app_id	=> '1232342342354',
 );
@@ -129,6 +139,7 @@ my $android_test_tags = q(<meta name="twitter:card" content="app"/>
 <meta property="og:type" content="product"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="app.app.com/app"/>
 <meta property="fb:app_id" content="1232342342354"/>);
@@ -144,11 +155,12 @@ my $ios_app_tags = HTML::SocialMeta->new(
     title => 'You can have any title you wish here',
     description => 'Description goes here may have to do a little validation',
     image => 'www.urltoimage.com/blah.jpg',
+    image_alt => 'A picture of some stuff.',
     url  => 'www.someurl.com',
     operatingSystem => 'IOS',
     app_country => 'US',
     app_name => 'tester twitter',
-    app_id => '1232', 
+    app_id => '1232',
     app_url => 'app.app.com/app',
     fb_app_id	=> '1232342342354',
 );
@@ -166,6 +178,7 @@ my $ios_test_tags = q(<meta name="twitter:card" content="app"/>
 <meta property="og:type" content="product"/>
 <meta property="og:title" content="You can have any title you wish here"/>
 <meta property="og:image" content="www.urltoimage.com/blah.jpg"/>
+<meta property="og:image:alt" content="A picture of some stuff."/>
 <meta property="og:description" content="Description goes here may have to do a little validation"/>
 <meta property="og:url" content="app.app.com/app"/>
 <meta property="fb:app_id" content="1232342342354"/>);


### PR DESCRIPTION
Adds support for image alt-text to both Twitter and OpenGraph output. The attribute is optional in both cases; if not provided it will generate an alt-text tag anyway with a value of `""`.

(Yes, by apparent coincidence, both Twitter and OpenGraph use the syntax "image:alt", according to the documentation of each.)