### PR TITLE
Making image_alt optional again

### DIFF
--- a/lib/HTML/SocialMeta/Base.pm
+++ b/lib/HTML/SocialMeta/Base.pm
@@ -12,7 +12,7 @@ attributes(
     [qw(card_type card type name url)] => [ rw, Str, {lzy} ],
     [qw(site fb_app_id site_name title description image creator operatingSystem app_country
     app_name app_id app_url player player_height player_width)] => [Str],
-    [qw(image_alt)] => [ Str, {lzy} ],
+    [qw(image_alt)] => [ Str, {lzy => 1, default => ''} ],
     [qw(card_options build_fields)] => [HashRef,{default => sub { {} }}],
     [qw(meta_attribute meta_namespace)] => [ro],
 );

--- a/t/04-create.t
+++ b/t/04-create.t
@@ -193,6 +193,24 @@ my $test_featured_twitter = '<meta name="twitter:card" content="summary_large_im
 
 is($create_twitter_featured, $test_featured_twitter);
 
+# Make sure that we can make a tags object with no optional tags defined
+my $only_required_meta_tags = HTML::SocialMeta->new(
+    card_type => 'summary',
+    site => '@example_twitter',
+    site_name => 'Example Site, anything',
+    title => 'You can have any title you wish here',
+    description => 'Description goes here may have to do a little validation',
+    image => 'www.urltoimage.com/blah.jpg',
+    player => 'www.somevideourl.com/url/url',
+    url	 => 'www.someurl.com',
+    player_width => '500',
+    player_height => '500',
+    fb_app_id	=> '1232342342354',
+);
+
+my $only_required_tags = $only_required_meta_tags->create;
+like ( $only_required_tags, qr{<meta name="twitter:image:alt" content=""/>});
+
 done_testing();
 
 1;


### PR DESCRIPTION
The docs describe the image_alt attribute as optional, but [this commit](https://github.com/ThisUsedToBeAnEmail/HTML-SocialMeta/commit/5459621b2f93ed2b95290972bb47f664ab523e35#diff-31518597129b63d824c9aa1c006b336b) reverted it to being required while still leaving the docs in that state. This patch restores this feature.